### PR TITLE
Align with claude-project-framework

### DIFF
--- a/.claude/context/signalk-guide.md
+++ b/.claude/context/signalk-guide.md
@@ -1,0 +1,316 @@
+# Signal K Quick Reference for AI Assistants
+
+**Purpose**: Help AI assistants quickly understand Signal K concepts and paths without reading the full specification.
+
+---
+
+## Tools Available
+
+### SignalK MCP Server
+
+You have access to the SignalK MCP server which provides real-time data from the Signal K server. Use these tools to:
+
+- **Check current state**: See live values when debugging
+- **Verify plugin output**: Confirm your plugin is publishing correctly
+- **Test subscriptions**: See what data is available before subscribing
+
+**Available MCP tools:**
+- `mcp__signalk__get_navigation_data` - Get position, heading, speed
+- `mcp__signalk__get_signalk_overview` - Get server info and available paths
+- `mcp__signalk__get_ais_targets` - Get nearby vessels
+- `mcp__signalk__get_system_alarms` - Get active alarms
+
+**When to use:**
+- When debugging: Check if values are being published correctly
+- Before subscribing: See what paths/data are available
+- During development: Verify your plugin's output in real-time
+
+---
+
+## What is Signal K?
+
+Signal K is an open marine data standard that provides:
+- A universal data format for marine instruments
+- JSON-based data model with hierarchical paths
+- WebSocket and REST APIs for real-time data
+- Standardized units (SI) across all measurements
+
+---
+
+## Key Documentation Sources
+
+| Resource | URL | Use For |
+|----------|-----|---------|
+| **Specification** | https://signalk.org/specification/latest/ | Full specification |
+| **Path Reference** | https://signalk.org/specification/1.5.0/doc/vesselsBranch.html | All vessel paths |
+| **Data Model** | https://signalk.org/specification/1.7.0/doc/data_model.html | Full vs delta format |
+| **Server Docs** | https://demo.signalk.org/documentation/ | Server implementation |
+
+---
+
+## Core Concepts
+
+### 1. Data Models
+
+**Delta Model** (most common):
+```json
+{
+  "context": "vessels.self",
+  "updates": [{
+    "source": {"label": "sensor1"},
+    "timestamp": "2025-12-02T10:30:00Z",
+    "values": [
+      {"path": "navigation.speedOverGround", "value": 3.5}
+    ]
+  }]
+}
+```
+
+**Full Model** (complete state snapshot):
+```json
+{
+  "version": "1.7.0",
+  "self": "vessels.urn:mrn:imo:mmsi:123456789",
+  "vessels": {
+    "urn:mrn:imo:mmsi:123456789": {
+      "navigation": {
+        "speedOverGround": {
+          "value": 3.5,
+          "timestamp": "2025-12-02T10:30:00Z",
+          "$source": "sensor1"
+        }
+      }
+    }
+  }
+}
+```
+
+### 2. Path Structure
+
+Paths use dot-notation hierarchy:
+```
+category.subcategory.property
+```
+
+Examples:
+- `navigation.speedOverGround`
+- `environment.depth.belowSurface`
+- `electrical.batteries.house.voltage`
+- `propulsion.port.revolutions`
+
+### 3. Units (Always SI)
+
+| Measurement | Unit | Notes |
+|-------------|------|-------|
+| Speed | m/s | NOT knots |
+| Distance | m | meters |
+| Temperature | K | Kelvin (add 273.15 to Celsius) |
+| Pressure | Pa | Pascals |
+| Angles | rad | radians (NOT degrees) |
+| Voltage | V | Volts |
+| Current | A | Amperes |
+| Frequency/RPM | Hz | multiply by 60 for RPM |
+| Volume | m³ | cubic meters |
+| Ratios | 0-1 | percentage as decimal |
+
+---
+
+## Common Signal K Paths
+
+### Navigation
+
+| Path | Description | Unit |
+|------|-------------|------|
+| `navigation.position.latitude` | Latitude | degrees |
+| `navigation.position.longitude` | Longitude | degrees |
+| `navigation.speedOverGround` | Speed over ground | m/s |
+| `navigation.courseOverGroundTrue` | Course (true) | rad |
+| `navigation.headingTrue` | Heading (true) | rad |
+| `navigation.anchor.position` | Anchor position | object |
+| `navigation.anchor.maxRadius` | Anchor alarm radius | m |
+| `navigation.anchor.currentRadius` | Distance from anchor | m |
+| `navigation.anchor.rodeDeployed` | Chain/rode out | m |
+
+### Environment
+
+| Path | Description | Unit |
+|------|-------------|------|
+| `environment.depth.belowSurface` | Water depth | m |
+| `environment.wind.speedTrue` | True wind speed | m/s |
+| `environment.wind.angleApparent` | Apparent wind angle | rad |
+| `environment.outside.temperature` | Air temperature | K |
+| `environment.water.temperature` | Water temperature | K |
+| `environment.tide.heightNow` | Current tide height | m |
+
+### Electrical
+
+| Path | Description | Unit |
+|------|-------------|------|
+| `electrical.batteries.{id}.voltage` | Battery voltage | V |
+| `electrical.batteries.{id}.current` | Battery current | A |
+| `electrical.batteries.{id}.stateOfCharge` | Charge level | 0-1 |
+
+### Propulsion
+
+| Path | Description | Unit |
+|------|-------------|------|
+| `propulsion.{id}.revolutions` | Engine RPM | Hz |
+| `propulsion.{id}.temperature` | Engine temp | K |
+| `propulsion.{id}.oilPressure` | Oil pressure | Pa |
+
+### Tanks
+
+| Path | Description | Unit |
+|------|-------------|------|
+| `tanks.fuel.{id}.currentLevel` | Fuel level | 0-1 |
+| `tanks.freshWater.{id}.currentLevel` | Water level | 0-1 |
+
+---
+
+## WebSocket API
+
+### Connection
+```
+ws://hostname:3000/signalk/v1/stream?subscribe=self
+```
+
+### Subscribe Message
+```json
+{
+  "context": "vessels.self",
+  "subscribe": [{
+    "path": "navigation.speedOverGround",
+    "period": 1000,
+    "policy": "ideal"
+  }]
+}
+```
+
+### Unsubscribe
+```json
+{
+  "context": "*",
+  "unsubscribe": [{"path": "*"}]
+}
+```
+
+---
+
+## REST API
+
+| Endpoint | Purpose |
+|----------|---------|
+| `GET /signalk` | Discovery |
+| `GET /signalk/v1/api/` | Full data |
+| `GET /signalk/v1/api/vessels/self/navigation/speedOverGround` | Specific path |
+| `PUT /signalk/v1/api/vessels/self/path` | Control command |
+
+---
+
+## Plugin PUT Handlers
+
+Register handlers to receive commands:
+
+```javascript
+app.registerPutHandler('navigation.anchor.setAnchor', 
+  (context, path, value, callback) => {
+    if (!value.latitude || !value.longitude) {
+      return callback({
+        state: 'COMPLETED',
+        statusCode: 400,
+        message: 'Missing required fields'
+      });
+    }
+    
+    // Do something with value
+    processAnchorSet(value);
+    
+    return callback({
+      state: 'COMPLETED',
+      statusCode: 200,
+      message: 'Anchor set successfully'
+    });
+  }
+);
+```
+
+### Calling via REST
+```bash
+curl -X PUT http://localhost:3000/signalk/v1/api/vessels/self/navigation/anchor/setAnchor \
+  -H "Content-Type: application/json" \
+  -d '{"value": {"latitude": 43.65, "longitude": 7.02}}'
+```
+
+---
+
+## Plugin Lifecycle
+
+```javascript
+module.exports = function(app) {
+  const plugin = {
+    id: 'my-plugin',
+    name: 'My Plugin',
+    
+    start: function(options) {
+      // Initialize plugin
+    },
+    
+    stop: function() {
+      // Cleanup
+    },
+    
+    schema: {
+      // Configuration schema
+    }
+  };
+  
+  return plugin;
+};
+```
+
+### Publishing Data
+```javascript
+app.handleMessage(plugin.id, {
+  updates: [{
+    values: [{
+      path: 'navigation.speedOverGround',
+      value: 3.5
+    }]
+  }]
+});
+```
+
+### Subscribing to Data
+```javascript
+app.subscriptionmanager.subscribe(
+  {
+    context: 'vessels.self',
+    subscribe: [{path: 'navigation.position'}]
+  },
+  unsubscribes,
+  (err) => { /* error handler */ },
+  (delta) => { /* data handler */ }
+);
+```
+
+---
+
+## Unit Conversions
+
+```
+Knots ↔ m/s:     knots × 0.514444 | m/s × 1.94384
+°C ↔ K:          °C + 273.15 | K - 273.15
+Degrees ↔ rad:   deg × (π/180) | rad × (180/π)
+PSI → Pa:        PSI × 6894.76
+Bar → Pa:        bar × 100000
+Hz ↔ RPM:        Hz × 60 | RPM / 60
+```
+
+---
+
+## Documentation Links
+
+- **Specification**: https://signalk.org/specification/latest/
+- **Path Reference**: https://signalk.org/specification/1.5.0/doc/vesselsBranch.html
+- **Server Docs**: https://demo.signalk.org/documentation/
+- **Plugin Dev**: https://demo.signalk.org/documentation/Developing/Plugins.html

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,7 @@ SignalK Server ←→ This Plugin ←→ Anchor Alarm Plugin
 | `safety.md` | Timing constraints, failure modes, gotchas |
 | `domain.md` | SignalK paths, API endpoints, auth |
 | `patterns.md` | JS coding standards, SignalK patterns |
+| `signalk-guide.md` | SignalK API reference, units, paths |
 
 ## External Systems
 


### PR DESCRIPTION
## Framework Alignment

Aligns signalk-anchorAlarmConnector with the claude-project-framework structure.

### Changes

1. **Added** `.claude/context/signalk-guide.md` - SignalK API reference now in the standard context location

2. **Updated** `CLAUDE.md` - Added signalk-guide.md to context files table

### Manual Cleanup Needed After Merge

Delete these redundant/backup files:
```bash
git rm docs/SIGNALK_GUIDE.md          # Moved to .claude/context/
git rm docs/SIGNALK_GUIDE.md.backup   # Old backup
git rm .gitignore.backup              # Old backup
git commit -m "Remove redundant files"
git push
```

### Result

Project now follows framework pattern:
- ✅ `CLAUDE.md` - Entry point
- ✅ `.claude/commands/` - implement, debug, review, test
- ✅ `.claude/context/` - architecture, safety, domain, patterns, **signalk-guide**
- ✅ `.eslintrc.json`, `.prettierrc` - Config files